### PR TITLE
Add endpoints to calculate Delta-W

### DIFF
--- a/plumber1.R
+++ b/plumber1.R
@@ -43,7 +43,9 @@ peekInput <- function(n_records) {
 
 
 #* @post /calculate_multiblock
-#* @param input:json Input for a selection of blocks in JSON format
+#* @param input:json Input should be a JSON array of objects,
+# each representing a block with fields such as code, prec_yr, prec_s,
+# epot_yr, epot_s, district, total_area, and other related attributes.
 calculateMultiblock <- function(input) {
   # Convert JSON to dataframe
   input <- fromJSON(input)
@@ -95,7 +97,10 @@ calculateAllDeltaW <- function() {
 
 
 #* @post /calculate_multiblock_delta_w
-#* @param input:json Input for a selection of blocks in JSON format
+#* @param input:json Input should be a JSON array of objects,
+# each representing a block with fields such as code, prec_yr, prec_s,
+# epot_yr, epot_s, district, total_area, and other related attributes.
+
 calculateMultiblockDeltaW <- function(input) {
   # Load Berlin data and config
   input_urban <- fromJSON(input)

--- a/plumber1.R
+++ b/plumber1.R
@@ -132,3 +132,37 @@ calculateMultiblock <- function(input) {
 
   return(rabimo_result)
 }
+
+
+#* @get /calculate_all_delta_w
+calculateAllDeltaW <- function() {
+  # Load Berlin data and config
+  input_urban <- kwb.rabimo::rabimo_inputs_2020$data
+  config <- kwb.rabimo::rabimo_inputs_2020$config
+
+  # Transform the data to its natural equivalent
+  input_natural <- kwb.rabimo:::check_or_convert_data_types(
+    data = input_urban,
+    types = kwb.rabimo:::get_expected_data_type(),
+    convert = TRUE
+  )
+
+  type <- "undeveloped"
+  input_natural <- kwb.rabimo::data_to_natural(data = input_natural, type = type)
+
+  # Get abimo outputs for urban and natural scenarios
+  output_urban <- kwb.rabimo::run_rabimo(
+    data = input_urban,
+    config = config
+  )
+
+  output_natural <- kwb.rabimo::run_rabimo(
+    data = input_natural,
+    config = config
+  )
+
+  # Calculate Delta-W
+  delta_w <- kwb.rabimo::calculate_delta_w(natural = output_natural, urban = output_urban)
+
+  return(delta_w)
+}

--- a/plumber1.R
+++ b/plumber1.R
@@ -47,79 +47,12 @@ peekInput <- function(n_records) {
 calculateMultiblock <- function(input) {
   # Convert JSON to dataframe
   input <- fromJSON(input)
-
-  # Define the required column names
-  required_columns <- c("code", "prec_yr", "prec_s", "epot_yr", "epot_s",
-                        "district", "total_area", "area_main", "area_rd",
-                        "main_fraction", "roof", "green_roof", "swg_roof",
-                        "pvd", "swg_pvd", "srf1_pvd", "srf2_pvd", "srf3_pvd",
-                        "srf4_pvd", "srf5_pvd", "road_fraction", "pvd_rd",
-                        "swg_pvd_rd", "srf1_pvd_rd", "srf2_pvd_rd", "srf3_pvd_rd",
-                        "srf4_pvd_rd", "sealed", "to_swale", "gw_dist", "ufc30",
-                        "ufc150", "land_type", "veg_class", "irrigation", "block_type")
-
-  # Check if all required columns are present
-  missing_columns <- setdiff(required_columns, names(input))
-  if (length(missing_columns) > 0) {
-    # Return a 400 Bad Request error response
-    response <- list(
-      error = "400 - Bad Request",
-      message = paste("Missing fields for all records:", paste(missing_columns, collapse = ", "))
-    )
-    return(response)
-  }
-
-  # Check for missing values in required columns
-  missing_values <- sapply(input[required_columns], function(column) any(is.na(column)))
-  if (any(missing_values)) {
-    missing_columns <- names(which(missing_values))
-    response <- list(
-      error = "400 - Bad Request",
-      message = paste("Missing fields for some records:", paste(missing_columns, collapse = ", "))
-    )
-    return(response)
-  }
-
-  # Convert specific columns to the appropriate data types
-  input <- input %>%
-    mutate(
-      code = as.character(code),
-      prec_yr = as.integer(prec_yr),
-      prec_s = as.integer(prec_s),
-      epot_yr = as.integer(epot_yr),
-      epot_s = as.integer(epot_s),
-      district = as.character(district),
-      total_area = as.numeric(total_area),
-      area_main = as.numeric(area_main),
-      area_rd = as.numeric(area_rd),
-      main_fraction = as.numeric(main_fraction),
-      roof = as.numeric(roof),
-      green_roof = as.numeric(green_roof),
-      swg_roof = as.numeric(swg_roof),
-      pvd = as.numeric(pvd),
-      swg_pvd = as.numeric(swg_pvd),
-      srf1_pvd = as.numeric(srf1_pvd),
-      srf2_pvd = as.numeric(srf2_pvd),
-      srf3_pvd = as.numeric(srf3_pvd),
-      srf4_pvd = as.numeric(srf4_pvd),
-      srf5_pvd = as.numeric(srf5_pvd),
-      road_fraction = as.numeric(road_fraction),
-      pvd_rd = as.numeric(pvd_rd),
-      swg_pvd_rd = as.numeric(swg_pvd_rd),
-      srf1_pvd_rd = as.numeric(srf1_pvd_rd),
-      srf2_pvd_rd = as.numeric(srf2_pvd_rd),
-      srf3_pvd_rd = as.numeric(srf3_pvd_rd),
-      srf4_pvd_rd = as.numeric(srf4_pvd_rd),
-      sealed = as.numeric(sealed),
-      to_swale = as.numeric(to_swale),
-      gw_dist = as.numeric(gw_dist),
-      ufc30 = as.numeric(ufc30),
-      ufc150 = as.numeric(ufc150),
-      land_type = as.character(land_type),
-      veg_class = as.integer(veg_class),
-      irrigation = as.integer(irrigation),
-      block_type = as.character(block_type)
-    )
+  # Validate data
+  input <- kwb.rabimo:::check_or_convert_data_types(
+    data = input,
+    types = kwb.rabimo:::get_expected_data_type(),
+    convert = TRUE
+  )
 
   # Load default configuration
   config <- kwb.rabimo::rabimo_inputs_2020$config

--- a/plumber1.R
+++ b/plumber1.R
@@ -159,3 +159,39 @@ calculateAllDeltaW <- function() {
 
   return(delta_w)
 }
+
+
+#* @post /calculate_multiblock_delta_w
+#* @param input:json Input for a selection of blocks in JSON format
+calculateMultiblockDeltaW <- function(input) {
+  # Load Berlin data and config
+  input_urban <- fromJSON(input)
+  config <- kwb.rabimo::rabimo_inputs_2020$config
+
+  # Validate data
+  input_urban <- kwb.rabimo:::check_or_convert_data_types(
+    data = input_urban,
+    types = kwb.rabimo:::get_expected_data_type(),
+    convert = TRUE
+  )
+
+  # Transform the data to its natural equivalent
+  type <- "undeveloped"
+  input_natural <- kwb.rabimo::data_to_natural(data = input_urban, type = type)
+
+  # Get abimo outputs for urban and natural scenarios
+  output_urban <- kwb.rabimo::run_rabimo(
+    data = input_urban,
+    config = config
+  )
+
+  output_natural <- kwb.rabimo::run_rabimo(
+    data = input_natural,
+    config = config
+  )
+
+  # Calculate Delta-W
+  delta_w <- kwb.rabimo::calculate_delta_w(natural = output_natural, urban = output_urban)
+
+  return(delta_w)
+}

--- a/plumber1.R
+++ b/plumber1.R
@@ -140,15 +140,8 @@ calculateAllDeltaW <- function() {
   input_urban <- kwb.rabimo::rabimo_inputs_2020$data
   config <- kwb.rabimo::rabimo_inputs_2020$config
 
-  # Transform the data to its natural equivalent
-  input_natural <- kwb.rabimo:::check_or_convert_data_types(
-    data = input_urban,
-    types = kwb.rabimo:::get_expected_data_type(),
-    convert = TRUE
-  )
-
   type <- "undeveloped"
-  input_natural <- kwb.rabimo::data_to_natural(data = input_natural, type = type)
+  input_natural <- kwb.rabimo::data_to_natural(data = input_urban, type = type)
 
   # Get abimo outputs for urban and natural scenarios
   output_urban <- kwb.rabimo::run_rabimo(


### PR DESCRIPTION
There are two new endpoints:

`/calculate_all_delta_w:`
Calculates Delta-W for all the blocks, using Berlin data imported from the Abimo package.

`/calculate_multiblock_delta_w:`
Calculates Delta-W for selected blocks, using input data in JSON format.

I also simplified the data validation in `/calculate_multiblock:` by using the abimo validation function `check_or_convert_data_types()`. Note: We only need this validation when the data is coming from outside the abimo package.